### PR TITLE
Replacement uint => uint32_t

### DIFF
--- a/ereg.c
+++ b/ereg.c
@@ -14,7 +14,7 @@
    +----------------------------------------------------------------------+
    | Authors: Rasmus Lerdorf <rasmus@php.net>                             |
    |          Jim Winstead <jimw@php.net>                                 |
-   |          Jaakko Hyv‰tti <jaakko@hyvatti.iki.fi>                      | 
+   |          Jaakko Hyv√§tti <jaakko@hyvatti.iki.fi>                      | 
    +----------------------------------------------------------------------+
  */
 /* $Id$ */
@@ -294,7 +294,7 @@ static void php_ereg(INTERNAL_FUNCTION_PARAMETERS, int icase)
 	regex_t re;
 	regmatch_t *subs;
 	int err, match_len, string_len;
-	uint i;
+	uint32_t i;
 	int copts = 0;
 	off_t start, end;
 	char *buf = NULL;
@@ -454,7 +454,7 @@ PHP_EREG_API char *php_ereg_replace(const char *pattern, const char *replace, co
 			   1) find out how long the string will be, and allocate buf
 			   2) copy the part before match, replacement and backrefs to buf
 
-			   Jaakko Hyv‰tti <Jaakko.Hyvatti@iki.fi>
+			   Jaakko Hyv√§tti <Jaakko.Hyvatti@iki.fi>
 			   */
 
 			new_l = strlen(buf) + subs[0].rm_so; /* part before the match */

--- a/ereg.c
+++ b/ereg.c
@@ -140,7 +140,8 @@ static int _php_regcomp(regex_t *preg, const char *pattern, int cflags)
 
 	if (zend_hash_num_elements(&EREG(ht_rc)) >= EREG_CACHE_SIZE) {
 		/* easier than dealing with overflow as it happens */
-		if (EREG(lru_counter) >= (1 << 31) || zend_hash_sort(&EREG(ht_rc), (compare_func_t)ereg_lru_cmp, 0) == FAILURE) {
+		zend_hash_sort(&EREG(ht_rc), (compare_func_t)ereg_lru_cmp, 0);
+		if (EREG(lru_counter) >= (1 << 31)) {
 			zend_hash_clean(&EREG(ht_rc));
 			EREG(lru_counter) = 0;
 		} else {

--- a/ereg.c
+++ b/ereg.c
@@ -564,7 +564,11 @@ static void php_do_ereg_replace(INTERNAL_FUNCTION_PARAMETERS, int icase)
 		if (Z_STRVAL_P(arg_pattern) && Z_STRLEN_P(arg_pattern)) {
 			pattern = zend_string_copy(Z_STR_P(arg_pattern));
 		} else {
+#if PHP_VERSION_ID >= 80500
+			pattern = ZSTR_EMPTY_ALLOC();
+#else
 			pattern = STR_EMPTY_ALLOC();
+#endif
 		}
 	} else {
 		convert_to_long_ex(arg_pattern);
@@ -577,7 +581,11 @@ static void php_do_ereg_replace(INTERNAL_FUNCTION_PARAMETERS, int icase)
 		if (Z_STRVAL_P(arg_replace) && Z_STRLEN_P(arg_replace)) {
 			replace = zend_string_copy(Z_STR_P(arg_replace));
 		} else {
+#if PHP_VERSION_ID >= 80500
+			replace = ZSTR_EMPTY_ALLOC();
+#else
 			replace = STR_EMPTY_ALLOC();
+#endif
 		}
 	} else {
 		convert_to_long_ex(arg_replace);
@@ -589,7 +597,11 @@ static void php_do_ereg_replace(INTERNAL_FUNCTION_PARAMETERS, int icase)
 	if (arg_string) {
 		string = zend_string_copy(arg_string);
 	} else {
+#if PHP_VERSION_ID >= 80500
+		string = ZSTR_EMPTY_ALLOC();
+#else
 		string = STR_EMPTY_ALLOC();
+#endif
 	}
 
 	/* do the actual work */


### PR DESCRIPTION
Comparable with https://github.com/php/php-src/commit/afb6ca2566691a673b7e638ffd7e3181e21d80a3
@LawnGnome @bjori : the change is needed for PHP 7.4. For the diehards that still have not removed all ereg_replace statements.

I do not know what was changed in the Authors. Probably something with unicode.